### PR TITLE
WorldBorder & Bastion Awareness

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,4 @@
+This source is licensed under the GNU General Public Licence v3 gplv:
+http://dev.bukkit.org/licenses/7-gnu-general-public-license-version-3-gplv3/
+
+The modification "World border & Bastion Aware" by github/suirad was published 20Jun2015

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: Random Spawn
 version: 2.6
 main: me.josvth.randomspawn.RandomSpawn
 author: Josvth
+softdepend: [WorldBorder, Bastion]
 commands:
   randomspawn:
     description: The main command.


### PR DESCRIPTION
Adds a soft dependency of Worldborder. Also has it check for it and makes sure chosen spawn locations are within world border. Should affect all cases where the plugin is used to choose the spawn.
